### PR TITLE
YHIOS-26. [IOS] Поправить отступы на кнопках на "Главной"

### DIFF
--- a/Home/Home/Sources/View/HomeView.swift
+++ b/Home/Home/Sources/View/HomeView.swift
@@ -121,7 +121,7 @@ struct HomeView: View {
                 Text(description)
                     .foregroundStyle(Color.black900)
                     .font(.manrope(.medium, size: 16))
-                    .frame(maxWidth: Constants.Button.descriptionMaxWidth, alignment: .leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                     .foregroundColor(.secondary)
             }
         }
@@ -138,8 +138,7 @@ extension HomeView {
 
         enum Button {
             static let horizontalInset: CGFloat = 12
-            static let verticalinset: CGFloat = 8
-            static let descriptionMaxWidth: CGFloat = 222
+            static let verticalinset: CGFloat = 4
             static let cornerRadius: CGFloat = 8
         }
 
@@ -150,7 +149,7 @@ extension HomeView {
             static let cornerRadius: CGFloat = 10
         }
 
-        static let gridSpacing: CGFloat = 8
+        static let gridSpacing: CGFloat = 4
         static let defaultInset: CGFloat = 16
         static let topInset: CGFloat = 24
         static let textsHeaderInset: CGFloat = 8


### PR DESCRIPTION
1) Была удаленна константа descriptionMaxWidth: CGFloat = 222, что задавала максимальный размер ячейки, в коде заменил на .infinity c принудительным отступом от экрана в 16 пикселей. 
2) Также подкорректировал отступы между иконками технологий в сетке, как по шаблону в Figma

ссылка на трекер - https://tracker.yandex.ru/YHIOS-26