### PR TITLE
bugfix/YHIOS-82-scroll-padding-fix

### DIFF
--- a/Collections/Collections/Source/Specializations/View/SpecializationsView.swift
+++ b/Collections/Collections/Source/Specializations/View/SpecializationsView.swift
@@ -41,6 +41,7 @@ struct SpecializationsView: View {
                     }
                 }
                 .padding(.vertical, Constants.defaultPadding)
+                .padding(.bottom, Constants.buttomScrollViewPadding)
             }
         }
         .background(Constants.background)
@@ -65,6 +66,8 @@ private extension SpecializationsView {
         static let roundedRectangleColor: Color = .white
         static let roundedRectangleHeight: CGFloat = 64
         static let roundedRectangleHorizontalPadding: CGFloat = 16
+        
+        static let buttomScrollViewPadding: CGFloat = 24
 
         static let specializationFont: Font = .manrope(.medium, size: 16)
         static let specializationColor: Color = .black900

--- a/SharedScreens/SharedScreens/QuestionModuleScreens/QuestionDetail/View/QuestionDetailView.swift
+++ b/SharedScreens/SharedScreens/QuestionModuleScreens/QuestionDetail/View/QuestionDetailView.swift
@@ -12,6 +12,7 @@ struct QuestionDetailView: View {
 
             YHBaseCell(state: .answer(title: Constants.longAnswerTitle, text: viewModel.question.longAnswer ?? ""))
         }
+        .padding(.bottom, Constants.buttomScrollViewPadding)
     }
 }
 
@@ -19,6 +20,8 @@ private extension QuestionDetailView {
     enum Constants {
         static let shortAnswerTitle = "Краткий ответ"
         static let longAnswerTitle = "Развернутый ответ"
+        
+        static let buttomScrollViewPadding: CGFloat = 32
     }
 }
 

--- a/SharedScreens/SharedScreens/QuestionModuleScreens/QuestionsSelectionScreens/View/QuestionsListView.swift
+++ b/SharedScreens/SharedScreens/QuestionModuleScreens/QuestionsSelectionScreens/View/QuestionsListView.swift
@@ -49,6 +49,7 @@ struct QuestionsListView: View {
                     }
                 }
                 .padding(.vertical, Constants.defaultPadding)
+                .padding(.bottom, Constants.buttomScrollViewPadding)
             }
             .background(Constants.background)
         }
@@ -62,6 +63,8 @@ private extension QuestionsListView {
         static let headerColor: Color = .black900
         static let headerHorizontalPadding: CGFloat = 16
         static let headerTopPadding: CGFloat = 24
+        
+        static let buttomScrollViewPadding: CGFloat = 24
 
         static let defaultSpacing: CGFloat = 8
         static let defaultPadding: CGFloat = 16

--- a/SharedScreens/SharedScreens/QuestionModuleScreens/Specializations/View/SpecializationsView.swift
+++ b/SharedScreens/SharedScreens/QuestionModuleScreens/Specializations/View/SpecializationsView.swift
@@ -47,6 +47,7 @@ struct SpecializationsView: View {
                     }
                 }
                 .padding(.vertical, Constants.defaultPadding)
+                .padding(.bottom, Constants.buttomScrollViewPadding)
             }
         }
         .background(Constants.background)
@@ -66,6 +67,8 @@ private extension SpecializationsView {
         static let defaultSpacing: CGFloat = 8
         static let defaultPadding: CGFloat = 16
         static let background: Color = .black10
+        
+        static let buttomScrollViewPadding: CGFloat = 24
 
         static let cornerRadius: CGFloat = 8
         static let roundedRectangleColor: Color = .white


### PR DESCRIPTION
Добавлен паддинг и вынесен в костанты для лучшего UI. Теперь контент из ScrollView не перекрывается кастомной кнопкой таба

<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2025-10-19 at 20 30 04" src="https://github.com/user-attachments/assets/7fac0dc1-ebf8-4e7e-aee2-4230fef5695f" />
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2025-10-19 at 20 29 53" src="https://github.com/user-attachments/assets/05ab28a2-8a8f-4a4b-a154-87821573bf8e" />
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2025-10-19 at 20 29 47" src="https://github.com/user-attachments/assets/188cccae-92a2-49d3-a1aa-eb62ad6bc991" />
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2025-10-19 at 20 29 43" src="https://github.com/user-attachments/assets/23d04313-f908-408b-804d-722ee79a4d7a" />
