### PR TITLE
YHIOS-71: добавлены UI компоненты для соответствия дизайну

### DIFF
--- a/CommonUI/CommonUI/Resources/Colors/Assets/Assets.xcassets/Arrow Icons/rightArrowIcon.imageset/Contents.json
+++ b/CommonUI/CommonUI/Resources/Colors/Assets/Assets.xcassets/Arrow Icons/rightArrowIcon.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Home/Home/Sources/View/HomeView.swift
+++ b/Home/Home/Sources/View/HomeView.swift
@@ -2,18 +2,18 @@ import SwiftUI
 import CommonUI
 
 struct HomeView: View {
-
+    
     private enum ImagesType {
         case frameworks
         case companies
     }
-
+    
     var body: some View {
         ZStack {
             Color.black10
                 .ignoresSafeArea()
             VStack(spacing: Constants.defaultInset) {
-                textsHeader
+                YHHeaderView(title: "Сервис подготовки к собеседованиям", subtitle: "Готовьтесь к собеседованию с подборками вопросов из крупных IT-компаний. Узнайте, какие вопросы задают в Сбере, Т-Банке, Яндексе, Авито, Ozon, VK и других компаниях.")
                 
                 button(
                     type: .frameworks,
@@ -21,14 +21,14 @@ struct HomeView: View {
                     description: "Большая база вопросов по 50+ востребованных технологий: JavaScript, React, Python, SQL и другие"
                 )
                 .defaultShadow()
-
+                
                 button(
                     type: .companies,
                     title: "Коллекции",
                     description: "Актуальные и востребованные вопросы с реальных технических собеседований"
                 )
                 .defaultShadow()
-
+                
                 Spacer()
             }
             .padding(.top, Constants.topInset)
@@ -36,27 +36,13 @@ struct HomeView: View {
         }
         .navigationBarHidden(true)
     }
-
-    private var textsHeader: some View {
-        VStack(alignment: .leading, spacing: Constants.textsHeaderInset) {
-            Text("Сервис подготовки к собеседованиям")
-                .foregroundStyle(Color.black900)
-                .font(.manrope(.semibold, size: 20))
-            
-            Text("Готовьтесь к собеседованию с подборками вопросов из крупных IT-компаний. Узнайте, какие вопросы задают в Сбере, Т-Банке, Яндексе, Авито, Ozon, VK и других компаниях.")
-                .foregroundStyle(Color.black900)
-                .font(.manrope(.medium, size: 16))
-                .foregroundColor(.secondary)
-        }
-        .padding(.bottom, Constants.textsHeaderInset)
-    }
-
+    
     private func imagesGrid(type: ImagesType) -> some View {
         let firstImage: Image
         let secondImage: Image
         let thirdImage: Image
         let fourthImage: Image
-
+        
         switch type {
         case .frameworks:
             firstImage = CommonUIAssets.image("pythonIcon")
@@ -69,7 +55,7 @@ struct HomeView: View {
             thirdImage = CommonUIAssets.image("sberIcon")
             fourthImage = CommonUIAssets.image("ozonIcon")
         }
-
+        
         return VStack(spacing: Constants.gridSpacing) {
             HStack(spacing: Constants.gridSpacing) {
                 icon(image: firstImage)
@@ -97,7 +83,7 @@ struct HomeView: View {
             }
         }
     }
-
+    
     private func icon(image: Image) -> some View {
         return ZStack {
             image
@@ -107,24 +93,30 @@ struct HomeView: View {
         .frame(width: Constants.iconSize, height: Constants.iconSize)
         
     }
-
+    
     private func button(
         type: ImagesType,
         title: String,
         description: String
     ) -> some View {
-        return HStack(alignment: .top, spacing: Constants.buttonHorizontalInset) {
+        HStack(alignment: .top, spacing: Constants.buttonHorizontalInset) {
             imagesGrid(type: type)
-
+            
             VStack(alignment: .leading, spacing: Constants.buttonVerticalInset) {
                 Text(title)
                     .foregroundStyle(Color.black900)
                     .font(.manrope(.medium, size: 20))
-                Text(description)
-                    .foregroundStyle(Color.black900)
-                    .font(.manrope(.medium, size: 16))
-                    .frame(maxWidth: Constants.buttonDescriptionMaxWidth, alignment: .leading)
-                    .foregroundColor(.secondary)
+                
+                HStack(alignment: .bottom, spacing: 4) {
+                    Text(description)
+                        .foregroundStyle(Color.black900)
+                        .font(.manrope(.medium, size: 16))
+                        .frame(maxWidth: Constants.buttonDescriptionMaxWidth, alignment: .leading)
+                        .foregroundColor(.secondary)
+                    
+                    CommonUIAssets.image(Constants.rightArrowIcon)
+                        .frame(width: Constants.arrowIconWidth, height: Constants.arrowIconHeight)
+                }
             }
         }
         .padding(.horizontal, Constants.buttonHorizontalInset)
@@ -148,10 +140,14 @@ extension HomeView {
         static let iconSize: CGFloat = 48
         static let iconCornerRadius: CGFloat = 10
         
-        static let gridSpacing: CGFloat = 8
+        static let gridSpacing: CGFloat = 4
         static let defaultInset: CGFloat = 16
         static let topInset: CGFloat = 24
         static let textsHeaderInset: CGFloat = 8
+        
+        static let rightArrowIcon = "rightArrowIcon"
+        static let arrowIconWidth: CGFloat = 20
+        static let arrowIconHeight: CGFloat = 20
     }
 }
 


### PR DESCRIPTION
Добавил стрелочки к комопнентам

Заменил заголовок на YHHeader

Сделал отступы в коллекции, как в дизайне
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2025-10-21 at 13 53 08" src="https://github.com/user-attachments/assets/ce1ca2da-2094-4d9f-ac46-a4a13020ba09" />