### PR TITLE
feature/YHIOS-52: add mode selection for YHTextfield with invalid state support

### DIFF
--- a/CommonUI/CommonUI/Resources/Colors/Colors.swift
+++ b/CommonUI/CommonUI/Resources/Colors/Colors.swift
@@ -17,6 +17,7 @@ public extension Color {
     static let pureWhite = Color(hex: "#FFFFFF")
     static let gray700 = Color(hex: "#6A6376")
     static let textBlack = Color(hex: "#141414")
+    static let red700 = Color(hex: "#D50B3E")
     static let red600 = Color(hex: "#F3164E")
     static let red100 = Color(hex: "#FDD8E1")
 

--- a/CommonUI/CommonUI/Sources/YHTextField/YHTextField.swift
+++ b/CommonUI/CommonUI/Sources/YHTextField/YHTextField.swift
@@ -3,17 +3,24 @@ import SwiftUI
 public struct YHTextField: View {
     
     @Binding var text: String
+    @Binding var isInvalid: Bool
     @FocusState private var isFocused: Bool
     @State private var isSecure: Bool = false
     
     private let placeholder: String
+    private let mode: Mode
     
     public init(
         text: Binding<String>,
-        placeholder: String = ""
+        isInvalid: Binding<Bool> = .constant(false),
+        placeholder: String = "",
+        mode: Mode = .text
     ) {
         self._text = text
+        self._isInvalid = isInvalid
         self.placeholder = placeholder
+        self.mode = mode
+        self._isSecure = State(initialValue: mode == .password ? true : false)
     }
     
     public var body: some View {
@@ -23,7 +30,7 @@ public struct YHTextField: View {
                     .focused($isFocused)
                     .font(Constants.textFieldFont)
                     .foregroundColor(isFocused ? Color.black900 : Color.black300)
-                    .textContentType(.password)
+                    .textContentType(mode == .password ? .password : .none)
                     .submitLabel(.done)
                     .opacity(isSecure ? 1.0 : 0.0)
                 
@@ -31,14 +38,16 @@ public struct YHTextField: View {
                     .focused($isFocused)
                     .font(Constants.textFieldFont)
                     .foregroundColor(isFocused ? Color.black900 : Color.black300)
-                    .textContentType(.password)
+                    .textContentType(mode == .password ? .password : .none)
                     .submitLabel(.done)
                     .opacity(isSecure ? 0.0 : 1.0)
             }
             
-            Button(action: performToggle) {
-                CommonUIAssets.image(isSecure ? Images.eyeSlash.rawValue : Images.eye.rawValue)
-                    .foregroundColor(isFocused ? Color.black900 : Color.black300)
+            if mode == .password {
+                Button(action: performToggle) {
+                    CommonUIAssets.image(isSecure ? Images.eyeSlash.rawValue : Images.eye.rawValue)
+                        .foregroundColor(isFocused ? Color.black900 : Color.black300)
+                }
             }
         }
         .padding(.horizontal, Constants.horizontalPadding)
@@ -49,12 +58,27 @@ public struct YHTextField: View {
         )
         .overlay(
             RoundedRectangle(cornerRadius: Constants.cornerRadius)
-                .stroke(isFocused ? Color.purple700 : Color.black50, lineWidth: 1)
+                .stroke(borderColor, lineWidth: 1)
         )
+    }
+    
+    private var borderColor: Color {
+        if isInvalid {
+            return Color.red700
+        } else {
+            return isFocused ? Color.purple700 : Color.black50
+        }
     }
     
     private func performToggle() {
         isSecure.toggle()
+    }
+}
+
+public extension YHTextField {
+    enum Mode {
+        case text
+        case password
     }
 }
 


### PR DESCRIPTION
https://tracker.yandex.ru/YHIOS-52
https://wiki.yandex.ru/homepage/ce33d84eb842/dizajjn-sistemacommonui/komponent-yhtextfield/

Была добавлена возможность использовать компонент в двух состояниях
Text:
<img width="242" height="39" alt="Screenshot 2025-10-27 at 11 25 31" src="https://github.com/user-attachments/assets/abd1b800-5e98-482e-84c5-3f83aeccd451" />
Password:
<img width="462" height="68" alt="Screenshot 2025-10-27 at 11 27 24" src="https://github.com/user-attachments/assets/35aadbb9-6530-462a-bf18-bff4b6290dc8" />
<img width="465" height="73" alt="Screenshot 2025-10-27 at 11 26 59" src="https://github.com/user-attachments/assets/ade2b1ac-8afc-4902-9872-6ebe0e38a747" />

Оба mode поддерживают isInvalid
<img width="376" height="63" alt="Screenshot 2025-10-27 at 11 29 32" src="https://github.com/user-attachments/assets/cf3476d6-d6a9-461e-8a8e-f8db053eeefe" />
<img width="395" height="62" alt="Screenshot 2025-10-27 at 11 31 41" src="https://github.com/user-attachments/assets/78bf0fc7-ff93-4477-a740-f2f56bf81467" />
